### PR TITLE
Clipr dev version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: r
 warnings_are_errors: true
-sudo: required
+sudo: false
 
 r:
  - oldrel

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,23 @@ r:
  - oldrel
  - release
  - devel
+# Create a build matrix that will test package with an empty DISPLAY value
+# (making the clipboard unavailable) and a correctly-configured DISPLAY (making
+# the clipboard available)
+env:
+  - DISPLAY=""
+  - DISPLAY=:99.0
+
+# Install xclip
+addons:
+  apt:
+    packages:
+      - xclip
+
+# Ensure xclip can still run headlessly
+before_script:
+  - sh -e /etc/init.d/xvfb start
+  - sleep 3
 
 apt_packages:
   - libv8-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
-language: r
-warnings_are_errors: true
-sudo: false
+# Sample .travis.yml for R projects
 
+language: r
 r:
- - oldrel
- - release
- - devel
+  - oldrel
+  - release
+  - devel
 # Create a build matrix that will test package with an empty DISPLAY value
 # (making the clipboard unavailable) and a correctly-configured DISPLAY (making
 # the clipboard available)
 env:
   - DISPLAY=""
   - DISPLAY=:99.0
+warnings_are_errors: true
+cache: packages
+sudo: false
+r_check_revdep: false
 
 # Install xclip
 addons:
@@ -23,19 +26,3 @@ addons:
 before_script:
   - sh -e /etc/init.d/xvfb start
   - sleep 3
-
-apt_packages:
-  - libv8-dev
-  - xclip
-
-env:
- global:
-   - CRAN: http://cran.rstudio.com
-
-notifications:
-  email:
-    - bob@rud.is
-  irc:
-    channels:
-      - "104.236.112.222#builds"
-    nick: travisci

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,11 +21,11 @@ Imports:
     curl,
     httr,
     purrr,
-    clipr,
     stringi,
     formatR,
     magrittr,
     jsonlite
+Remotes: mdlincoln/clipr
 License: AGPL
 LazyData: true
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     curl,
     httr,
     purrr,
+    clipr,
     stringi,
     formatR,
     magrittr,

--- a/R/curlconverter.r
+++ b/R/curlconverter.r
@@ -17,11 +17,11 @@
 #'             \href{https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor}{Network Monitor}
 #' @export
 #' @examples
+#' \dontrun{
 #' library(httr)
 #'
 #' my_ip <- straighten("curl 'https://httpbin.org/ip'") %>% make_req()
 #'
-#' \dontrun{
 #' # external test which captures live data
 #' content(my_ip[[1]](), as="parsed")
 #' }

--- a/R/make_req.r
+++ b/R/make_req.r
@@ -20,11 +20,11 @@
 #' @references \href{https://developer.chrome.com/devtools/docs/network}{Evaluating Network Performance},
 #'             \href{https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor}{Network Monitor}
 #' @examples
+#' \dontrun{
 #' library(httr)
 #'
 #' my_ip <- straighten("curl 'https://httpbin.org/ip'") %>% make_req()
 #'
-#' \dontrun{
 #' # external test which captures live data
 #' content(my_ip[[1]](), as="parsed")
 #' }

--- a/man/make_req.Rd
+++ b/man/make_req.Rd
@@ -31,11 +31,11 @@ into working \code{httr} \code{\link[httr]{VERB}()} functions, optionally \code{
 to the console and/or replacing the system clipboard with the source code for the function.
 }
 \examples{
+\dontrun{
 library(httr)
 
 my_ip <- straighten("curl 'https://httpbin.org/ip'") \%>\% make_req()
 
-\dontrun{
 # external test which captures live data
 content(my_ip[[1]](), as="parsed")
 }

--- a/man/straighten.Rd
+++ b/man/straighten.Rd
@@ -25,11 +25,11 @@ components that can be used to build \code{httr} requests or passed to
 \code{\link[httr]{VERB}()} function.
 }
 \examples{
+\dontrun{
 library(httr)
 
 my_ip <- straighten("curl 'https://httpbin.org/ip'") \%>\% make_req()
 
-\dontrun{
 # external test which captures live data
 content(my_ip[[1]](), as="parsed")
 }

--- a/tests/testthat/test-curconverterl.R
+++ b/tests/testthat/test-curconverterl.R
@@ -1,6 +1,6 @@
 context("cURL processing")
 test_that("straighten works", {
-  skip_if_not(clipr_available())
+  skip_if_not(clipr::clipr_available())
   expect_that(all(c(6L, 8L, 6L, 6L, 4L, 5L, 6L, 5L, 6L, 6L) ==
                     sapply(
                       sapply(
@@ -14,7 +14,7 @@ test_that("straighten works", {
 })
 
 test_that("make_req works", {
-  skip_if_not(clipr_available())
+  skip_if_not(clipr::clipr_available())
   lapply(sapply(list.files(system.file("extdata",
                                        package="curlconverter"),
                         full.names=TRUE),

--- a/tests/testthat/test-curconverterl.R
+++ b/tests/testthat/test-curconverterl.R
@@ -1,6 +1,6 @@
 context("cURL processing")
 test_that("straighten works", {
-
+  skip_if_not(clipr_available())
   expect_that(all(c(6L, 8L, 6L, 6L, 4L, 5L, 6L, 5L, 6L, 6L) ==
                     sapply(
                       sapply(
@@ -14,7 +14,7 @@ test_that("straighten works", {
 })
 
 test_that("make_req works", {
-
+  skip_if_not(clipr_available())
   lapply(sapply(list.files(system.file("extdata",
                                        package="curlconverter"),
                         full.names=TRUE),


### PR DESCRIPTION
This fix:

- Wraps all examples in `\dontrun{}`
- Skips tests if `clipr::clipr_available()` returns `FALSE`